### PR TITLE
Update Dockerfile to include bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.18
 RUN apk update
-RUN apk add clang lld git make llvm
+RUN apk add clang lld git make llvm bash
 
 RUN git clone https://github.com/CraneStation/wasi-libc.git && \
     cd /wasi-libc && \


### PR DESCRIPTION
Per 

https://github.com/wokwi/wokwi-chip-clang-action/issues/1

Adding 'bash' to the docker image per:

https://github.com/wokwi/wokwi-chip-clang-action/issues/1#issuecomment-2642237152

...seems to work for me:

https://github.com/drf5n/Wokwi-Chip-LimitCounter/actions/runs/13196246352/job/36838137133